### PR TITLE
Keep hidden attributes

### DIFF
--- a/src/Models/Concerns/KeepsDeletedModels.php
+++ b/src/Models/Concerns/KeepsDeletedModels.php
@@ -41,7 +41,15 @@ trait KeepsDeletedModels
 
     public function attributesToKeep(): array
     {
-        return $this->toArray();
+        $hiddenAttributes = $this->getHidden();
+
+        $this->makeVisible($hiddenAttributes);
+
+        $attributes = $this->toArray();
+
+        $this->makeHidden($hiddenAttributes);
+
+        return $attributes;
     }
 
     public function deleteWithoutKeeping()

--- a/tests/KeepsDeletedModelsTest.php
+++ b/tests/KeepsDeletedModelsTest.php
@@ -12,9 +12,12 @@ beforeEach(function () {
 
     Relation::morphMap([], merge: false);
 
-    $this->model = TestModel::factory()->create([
+    $this->attributes = [
         'name' => 'John Doe',
-    ]);
+        'secret' => 'hash',
+    ];
+
+    $this->model = TestModel::factory()->create($this->attributes);
 });
 
 it('will copy a deleted model to the deleted models table', function () {
@@ -65,6 +68,7 @@ it('can restore a deleted model', function () {
     expect($restoredModel)
         ->id->toBe(1)
         ->name->toBe('John Doe')
+        ->secret->toBe('hash')
         ->created_at->format('Y-m-d H:i:s')->toBe('2023-01-01 00:00:00')
         ->updated_at->format('Y-m-d H:i:s')->toBe('2023-01-01 00:00:00');
 });
@@ -91,7 +95,7 @@ it('can be configured to not keep a deleted model', function () {
     };
 
     $model
-        ->fill(['name' => 'John Doe'])
+        ->fill($this->attributes)
         ->save();
 
     $model->delete();
@@ -111,7 +115,7 @@ it('can determine the attributes to be stored', function () {
     };
 
     $model
-        ->fill(['name' => 'John Doe'])
+        ->fill($this->attributes)
         ->save();
 
     $model->delete();
@@ -135,3 +139,15 @@ it('will throw an exception when the model cannot be restored', function () {
 
     TestModel::restore($id);
 })->throws(CouldNotRestoreModel::class);
+
+it('will save hidden attributes as well', function () {
+    $this->model->delete();
+
+    expect(DeletedModel::count())->toBe(1);
+
+    $deletedModel = DeletedModel::first();
+
+    expect($deletedModel->values)
+        ->id->toBe(1)
+        ->secret->toBe('hash');
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -36,6 +36,7 @@ class TestCase extends Orchestra
         Schema::create('test_models', function (Blueprint $table) {
             $table->id();
             $table->string('name');
+            $table->string('secret');
             $table->timestamps();
         });
     }

--- a/tests/TestSupport/Database/Factories/TestModelFactory.php
+++ b/tests/TestSupport/Database/Factories/TestModelFactory.php
@@ -13,6 +13,7 @@ class TestModelFactory extends Factory
     {
         return [
             'name' => $this->faker->name,
+            'secret' => $this->faker->password,
         ];
     }
 }

--- a/tests/TestSupport/Models/TestModel.php
+++ b/tests/TestSupport/Models/TestModel.php
@@ -10,6 +10,10 @@ class TestModel extends Model
 {
     public $guarded = [];
 
+    public $hidden = [
+        'secret',
+    ];
+
     public $table = 'test_models';
 
     use KeepsDeletedModels;


### PR DESCRIPTION
I like this alternative to the soft delete concept, so I immediately started to test this package on my local machine. 
I know this is still in the development phase and don't if you are accepting PRs at the moment, but I played a bit with the Laravel default users table and realized that hidden attributes are not transferred to "deleted_models" table. This PR is trying to fix that by making hidden attributes visible before serialization and returning them back to hidden after that.