### PR TITLE
Remove relationships from deleted object

### DIFF
--- a/src/Models/Concerns/KeepsDeletedModels.php
+++ b/src/Models/Concerns/KeepsDeletedModels.php
@@ -50,7 +50,7 @@ trait KeepsDeletedModels
 
         $cloned->makeVisible($hiddenAttributes);
 
-        return $cloned->toArray();
+        return $cloned->attributesToArray();
     }
 
     public function deleteWithoutKeeping()

--- a/tests/KeepsDeletedModelsTest.php
+++ b/tests/KeepsDeletedModelsTest.php
@@ -4,6 +4,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Spatie\DeletedModels\Exceptions\CouldNotRestoreModel;
 use Spatie\DeletedModels\Exceptions\NoModelFoundToRestore;
 use Spatie\DeletedModels\Models\DeletedModel;
+use Spatie\DeletedModels\Tests\TestSupport\Models\RelatedModel;
 use Spatie\DeletedModels\Tests\TestSupport\Models\TestModel;
 use function Spatie\PestPluginTestTime\testTime;
 
@@ -171,4 +172,18 @@ it('will return null when making a non-existing model', function () {
     $testModel = TestModel::makeRestored('non-existing-key');
 
     expect($testModel)->toBeNull();
+});
+
+it('will not save relationship objects', function () {
+    RelatedModel::factory()->for($this->model)->create();
+
+    $this->model->load('relatedModel');
+
+    $this->model->delete();
+
+    expect(DeletedModel::count())->toBe(1);
+
+    $deletedModel = DeletedModel::first();
+
+    expect($deletedModel->values)->not()->toHaveKey('related_model');
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -39,5 +39,17 @@ class TestCase extends Orchestra
             $table->string('secret');
             $table->timestamps();
         });
+
+        Schema::create('related_models', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('test_model_id');
+            $table->string('name');
+            $table->timestamps();
+
+            $table->foreign('test_model_id')
+                ->references('id')
+                ->on('test_models')
+                ->onDelete('cascade');
+        });
     }
 }

--- a/tests/TestSupport/Database/Factories/RelatedModelFactory.php
+++ b/tests/TestSupport/Database/Factories/RelatedModelFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\DeletedModels\Tests\TestSupport\Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Spatie\DeletedModels\Tests\TestSupport\Models\RelatedModel;
+use Spatie\DeletedModels\Tests\TestSupport\Models\TestModel;
+
+class RelatedModelFactory extends Factory
+{
+    public $model = RelatedModel::class;
+
+    public function definition()
+    {
+        return [
+            'test_model_id' => TestModel::factory(),
+            'name' => $this->faker->name,
+        ];
+    }
+}

--- a/tests/TestSupport/Models/RelatedModel.php
+++ b/tests/TestSupport/Models/RelatedModel.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\DeletedModels\Tests\TestSupport\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class RelatedModel extends Model
+{
+    use HasFactory;
+
+    public $guarded = [];
+
+    public $table = 'related_models';
+
+    public function testModel()
+    {
+        return $this->belongsTo(TestModel::class);
+    }
+}

--- a/tests/TestSupport/Models/TestModel.php
+++ b/tests/TestSupport/Models/TestModel.php
@@ -18,4 +18,9 @@ class TestModel extends Model
 
     use KeepsDeletedModels;
     use HasFactory;
+
+    public function relatedModel()
+    {
+        return $this->hasOne(RelatedModel::class);
+    }
 }


### PR DESCRIPTION
Sometimes deleted object can have too many relationships attached, so maybe it would be better to save only attributes from the deleted model. Hopefully, it is not expected behavior because of some future plans with this package. If it is, sorry for bothering you. 😊 