### PR TITLE
Custom deleted model class

### DIFF
--- a/src/DeletedModelsServiceProvider.php
+++ b/src/DeletedModelsServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\DeletedModels;
 
+use Spatie\DeletedModels\Exceptions\InvalidDeletedModel;
+use Spatie\DeletedModels\Models\DeletedModel;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 
@@ -13,5 +15,19 @@ class DeletedModelsServiceProvider extends PackageServiceProvider
             ->name('laravel-deleted-models')
             ->hasConfigFile()
             ->hasMigration('create_deleted_models_table');
+    }
+
+    public function packageBooted()
+    {
+        $this->guardAgainstInvalidDeletedModel();
+    }
+
+    public function guardAgainstInvalidDeletedModel()
+    {
+        $modelClassName = config('deleted-models.model');
+
+        if (! is_a($modelClassName, DeletedModel::class, true)) {
+            throw InvalidDeletedModel::create($modelClassName);
+        }
     }
 }

--- a/src/Exceptions/InvalidDeletedModel.php
+++ b/src/Exceptions/InvalidDeletedModel.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\DeletedModels\Exceptions;
+
+use Exception;
+
+class InvalidDeletedModel extends Exception
+{
+    public static function create(string $model): self
+    {
+        return new self("The model `{$model}` is invalid. A valid model must extend the model \Spatie\DeletedModels\Models\DeletedModel.");
+    }
+}

--- a/src/Models/Concerns/KeepsDeletedModels.php
+++ b/src/Models/Concerns/KeepsDeletedModels.php
@@ -23,10 +23,7 @@ trait KeepsDeletedModels
                 return;
             }
 
-            /** @var class-string<DeletedModel> $deletedModelClass */
-            $deletedModelClass = config('deleted-models.model');
-
-            $deletedModelClass::create([
+            static::getDeletedModelClassName()::create([
                 'key' => $model->getKey(),
                 'model' => $model->getMorphClass(),
                 'values' => $model->attributesToKeep(),
@@ -66,7 +63,7 @@ trait KeepsDeletedModels
     {
         $model = (new self)->getMorphClass();
 
-        return DeletedModel::query()->where('model', $model);
+        return static::getDeletedModelClassName()::query()->where('model', $model);
     }
 
     public static function restore(mixed $key): Model
@@ -118,6 +115,11 @@ trait KeepsDeletedModels
         Model $restoredMode,
         DeletedModel $deletedModel
     ): void {
+    }
+
+    protected static function getDeletedModelClassName()
+    {
+        return config('deleted-models.model');
     }
 
     protected static function findDeletedModelToRestore(mixed $key): DeletedModel

--- a/src/Models/DeletedModel.php
+++ b/src/Models/DeletedModel.php
@@ -25,6 +25,8 @@ class DeletedModel extends Model
 
     public $guarded = [];
 
+    public $table = 'deleted_models';
+
     public function restore(): Model
     {
         event(new RestoringDeletedModelEvent($this));

--- a/tests/KeepsDeletedModelsTest.php
+++ b/tests/KeepsDeletedModelsTest.php
@@ -4,6 +4,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Spatie\DeletedModels\Exceptions\CouldNotRestoreModel;
 use Spatie\DeletedModels\Exceptions\NoModelFoundToRestore;
 use Spatie\DeletedModels\Models\DeletedModel;
+use Spatie\DeletedModels\Tests\TestSupport\Models\CustomDeletedModel;
 use Spatie\DeletedModels\Tests\TestSupport\Models\RelatedModel;
 use Spatie\DeletedModels\Tests\TestSupport\Models\TestModel;
 use function Spatie\PestPluginTestTime\testTime;
@@ -186,4 +187,16 @@ it('will not save relationship objects', function () {
     $deletedModel = DeletedModel::first();
 
     expect($deletedModel->values)->not()->toHaveKey('related_model');
+});
+
+it('can use custom deleted model class', function () {
+    config(['deleted-models.model' => CustomDeletedModel::class]);
+
+    $this->model->delete();
+
+    $deletedModel = TestModel::deletedModels()
+        ->where('key', $this->model->id)
+        ->first();
+
+    expect($deletedModel)->toBeInstanceOf(CustomDeletedModel::class);
 });

--- a/tests/TestSupport/Models/CustomDeletedModel.php
+++ b/tests/TestSupport/Models/CustomDeletedModel.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Spatie\DeletedModels\Tests\TestSupport\Models;
+
 use Spatie\DeletedModels\Models\DeletedModel;
 
 class CustomDeletedModel extends DeletedModel

--- a/tests/TestSupport/Models/CustomDeletedModel.php
+++ b/tests/TestSupport/Models/CustomDeletedModel.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Spatie\DeletedModels\Tests\TestSupport\Models;
+use Spatie\DeletedModels\Models\DeletedModel;
+
+class CustomDeletedModel extends DeletedModel
+{
+}


### PR DESCRIPTION
This PR allows full usage of the custom deleted model class. Besides that, validation on the service provider level is added, to be sure that configured model is an instance of the package DeletedModel class.