### PR TITLE
Revert guarded fields to original table as well

### DIFF
--- a/src/Models/DeletedModel.php
+++ b/src/Models/DeletedModel.php
@@ -65,9 +65,7 @@ class DeletedModel extends Model
     {
         $modelClass = $this->getModelClass();
 
-        $model = (new $modelClass)->fill($this->values);
-
-        return $model;
+        return (new $modelClass)->forceFill($this->values);
     }
 
     public function beforeSavingRestoredModel(): void

--- a/tests/TestSupport/Models/TestModel.php
+++ b/tests/TestSupport/Models/TestModel.php
@@ -8,7 +8,10 @@ use Spatie\DeletedModels\Models\Concerns\KeepsDeletedModels;
 
 class TestModel extends Model
 {
-    public $guarded = [];
+    public $fillable = [
+        'name',
+        'secret',
+    ];
 
     public $hidden = [
         'secret',


### PR DESCRIPTION
When some fields are marked as guarded, or they are not in the fillable list, restore will not revert guarded fields to the original table. Didn't write a test for that, because it's already covered with existing tests. It was enough only to change fillable attributes on TestModel.