### PR TITLE
Update create_deleted_models_table.php

### DIFF
--- a/database/migrations/create_deleted_models_table.php
+++ b/database/migrations/create_deleted_models_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
         Schema::create('deleted_models', function (Blueprint $table) {
             $table->id();
 
-            $table->integer('key');
+            $table->string('key', 40);
             $table->string('model');
             $table->json('values');
 


### PR DESCRIPTION
If primary key is **uuid** then key type **integer** will throw an exception at the time of deletion. Please add in documentation if someone is using primary key type **uuid** and implemented **static::creating()** method in model he has to use **restoreQuietly()** method instead of **restore()** method. 