### PR TITLE
Move pest test time package to require dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,7 @@
     "require": {
         "php": "^8.1",
         "illuminate/contracts": "^9.0|^10",
-        "spatie/laravel-package-tools": "^1.13.0",
-        "spatie/pest-plugin-test-time": "^1.1"
+        "spatie/laravel-package-tools": "^1.13.0"
     },
     "require-dev": {
         "laravel/pint": "^1.0",
@@ -32,7 +31,8 @@
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
         "phpunit/phpunit": "^9.5",
-        "spatie/laravel-ray": "^1.26"
+        "spatie/laravel-ray": "^1.26",
+        "spatie/pest-plugin-test-time": "^1.1"
     },
     "autoload": {
         "psr-4": {

--- a/tests/KeepsDeletedModelsTest.php
+++ b/tests/KeepsDeletedModelsTest.php
@@ -34,7 +34,7 @@ it('will copy a deleted model to the deleted models table', function () {
     $deletedModel = DeletedModel::first();
 
     expect($deletedModel)
-        ->key->toBe(1)
+        ->key->toBe('1')
         ->model->toBe(TestModel::class);
 
     expect($deletedModel->values)


### PR DESCRIPTION
Minor change. Clear from the title probably. Just moved "spatie/pest-plugin-test-time" to dev dependencies, since we are using it only in test cases, I guess.

Besides that, one test was failing because the "key" column became a string, instead of an integer. That should be fixed as well.